### PR TITLE
🥳 aws-vpc-cni v1.10.1 Automated Release! 🥑

### DIFF
--- a/stable/aws-vpc-cni/Chart.yaml
+++ b/stable/aws-vpc-cni/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-vpc-cni
-version: 1.1.10
-appVersion: "v1.9.3"
+version: 1.1.12
+appVersion: "v1.10.1"
 description: A Helm chart for the AWS VPC CNI
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 home: https://github.com/aws/amazon-vpc-cni-k8s

--- a/stable/aws-vpc-cni/templates/clusterrole.yaml
+++ b/stable/aws-vpc-cni/templates/clusterrole.yaml
@@ -14,10 +14,17 @@ rules:
     resources:
       - namespaces
     verbs: ["list", "watch", "get"]
+{{- if .Values.env.ANNOTATE_POD_IP }}
   - apiGroups: [""]
     resources:
       - pods
     verbs: ["list", "watch", "get", "patch"]
+{{- else }}
+  - apiGroups: [""]
+    resources:
+      - pods
+    verbs: ["list", "watch", "get"]
+{{- end }}        
   - apiGroups: [""]
     resources:
       - nodes

--- a/stable/aws-vpc-cni/templates/customresourcedefinition.yaml
+++ b/stable/aws-vpc-cni/templates/customresourcedefinition.yaml
@@ -8,6 +8,7 @@ metadata:
 spec:
   scope: Cluster
   group: crd.k8s.amazonaws.com
+  preserveUnknownFields: false
   versions:
     - name: v1alpha1
       served: true

--- a/stable/aws-vpc-cni/templates/daemonset.yaml
+++ b/stable/aws-vpc-cni/templates/daemonset.yaml
@@ -2,6 +2,7 @@ kind: DaemonSet
 apiVersion: apps/v1
 metadata:
   name: {{ include "aws-vpc-cni.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "aws-vpc-cni.labels" . | indent 4 }}
 spec:
@@ -39,8 +40,7 @@ spec:
       hostNetwork: true
       initContainers:
       - name: aws-vpc-cni-init
-        image: "{{- if .Values.init.image.override }}{{- .Values.init.image.override }}{{- else }}602401143452.dkr.ecr.{{- .Values.init.image.region }}.amazonaws.com/amazon-k8s-cni-init:{{- .Values.init.image.tag }}{{- end}}"
-        imagePullPolicy: {{ .Values.init.image.pullPolicy }}
+        image: "{{- if .Values.init.image.override }}{{- .Values.init.image.override }}{{- else }}{{- .Values.init.image.account }}.dkr.ecr.{{- .Values.init.image.region }}.{{- .Values.init.image.domain }}/amazon-k8s-cni-init:{{- .Values.init.image.tag }}{{- end}}"
         env:
 {{- range $key, $value := .Values.init.env }}
           - name: {{ $key }}
@@ -62,15 +62,16 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: aws-node
-          image: "{{- if .Values.image.override }}{{- .Values.image.override }}{{- else }}602401143452.dkr.ecr.{{- .Values.image.region }}.amazonaws.com/amazon-k8s-cni:{{- .Values.image.tag }}{{- end}}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: "{{- if .Values.image.override }}{{- .Values.image.override }}{{- else }}{{- .Values.image.account }}.dkr.ecr.{{- .Values.image.region }}.{{- .Values.image.domain }}/amazon-k8s-cni:{{- .Values.image.tag }}{{- end}}"
           ports:
             - containerPort: 61678
               name: metrics
           livenessProbe:
 {{ toYaml .Values.livenessProbe | indent 12 }}
+            timeoutSeconds: {{ .Values.livenessProbeTimeoutSeconds }}
           readinessProbe:
 {{ toYaml .Values.readinessProbe | indent 12 }}
+            timeoutSeconds: {{ .Values.readinessProbeTimeoutSeconds }}
           env:
 {{- range $key, $value := .Values.env }}
             - name: {{ $key }}

--- a/stable/aws-vpc-cni/templates/serviceaccount.yaml
+++ b/stable/aws-vpc-cni/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "aws-vpc-cni.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
 {{- with .Values.serviceAccount.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}

--- a/stable/aws-vpc-cni/values.yaml
+++ b/stable/aws-vpc-cni/values.yaml
@@ -8,19 +8,24 @@ nameOverride: aws-node
 
 init:
   image:
-    tag: v1.9.3
+    tag: v1.10.1
     region: us-west-2
+    account: "602401143452"   
     pullPolicy: Always
+    domain: "amazonaws.com"  
     # Set to use custom image
     # override: "repo/org/image:tag"
   env:
     DISABLE_TCP_EARLY_DEMUX: "false"
+    ENABLE_IPv6: "false"
   securityContext:
     privileged: true
 
 image:
   region: us-west-2
-  tag: v1.9.3
+  tag: v1.10.1
+  account: "602401143452"   
+  domain: "amazonaws.com"  
   pullPolicy: Always
   # Set to use custom image
   # override: "repo/org/image:tag"
@@ -47,6 +52,8 @@ env:
   WARM_ENI_TARGET: "1"
   WARM_PREFIX_TARGET: "1"
   DISABLE_NETWORK_RESOURCE_PROVISIONING: "false"
+  ENABLE_IPv4: "true"
+  ENABLE_IPv6: "false"
 
 # this flag enables you to use the match label that was present in the original daemonset deployed by EKS
 # You can then annotate and label the original aws-node resources and 'adopt' them into a helm release
@@ -90,14 +97,22 @@ livenessProbe:
     command:
       - /app/grpc-health-probe
       - '-addr=:50051'
+      - '-connect-timeout=5s'
+      - '-rpc-timeout=5s'
   initialDelaySeconds: 60
+
+livenessProbeTimeoutSeconds: 10
 
 readinessProbe:
   exec:
     command:
       - /app/grpc-health-probe
       - '-addr=:50051'
+      - '-connect-timeout=5s'
+      - '-rpc-timeout=5s'
   initialDelaySeconds: 1
+
+readinessProbeTimeoutSeconds: 10
 
 resources:
   requests:
@@ -116,20 +131,6 @@ affinity:
   nodeAffinity:
     requiredDuringSchedulingIgnoredDuringExecution:
       nodeSelectorTerms:
-        - matchExpressions:
-            - key: "beta.kubernetes.io/os"
-              operator: In
-              values:
-                - linux
-            - key: "beta.kubernetes.io/arch"
-              operator: In
-              values:
-                - amd64
-                - arm64
-            - key: "eks.amazonaws.com/compute-type"
-              operator: NotIn
-              values:
-                - fargate
         - matchExpressions:
             - key: "kubernetes.io/os"
               operator: In


### PR DESCRIPTION
  ## aws-vpc-cni v1.10.1 Automated Chart Sync! 🤖🤖

  ### Release Notes 📝:

  ## v1.10.1

#### Release Notes: 
v1.10.1 removes IMDSv1 dependency from VPC CNI.

* Bug - [Remove IMDSv1 Dependency](https://github.com/aws/amazon-vpc-cni-k8s/pull/1743)(#1743, [@chlunde)](https://github.com/chlunde)


#### To apply this release: 

```
kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/release-1.10/config/master/aws-k8s-cni.yaml
```


#### Verify the update:

```
$ kubectl describe daemonset aws-node -n kube-system | grep Image | cut -d "/" -f 2                                                   
amazon-k8s-cni-init:v1.10.1
amazon-k8s-cni:v1.10.1
```

#### Note: 
Amazon EKS does not yet support IPv6. You can follow progress on this feature by subscribing to the [issue](https://github.com/aws/containers-roadmap/issues/835) for EKS IPv6 support on the containers roadmap. 