### PR TITLE
🥳 cni-metrics-helper v1.10.1 Automated Release! 🥑

### DIFF
--- a/stable/cni-metrics-helper/.helmignore
+++ b/stable/cni-metrics-helper/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/stable/cni-metrics-helper/Chart.yaml
+++ b/stable/cni-metrics-helper/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: cni-metrics-helper
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.6
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: v1.10.1

--- a/stable/cni-metrics-helper/templates/NOTES.txt
+++ b/stable/cni-metrics-helper/templates/NOTES.txt
@@ -1,0 +1,3 @@
+{{ .Release.Name }} has been installed or updated. To check the status of pods, run:
+
+kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "cni-metrics-helper.name" . }},app.kubernetes.io/instance={{ .Release.Name }}"

--- a/stable/cni-metrics-helper/templates/_helpers.tpl
+++ b/stable/cni-metrics-helper/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "cni-metrics-helper.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "cni-metrics-helper.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "cni-metrics-helper.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "cni-metrics-helper.labels" -}}
+helm.sh/chart: {{ include "cni-metrics-helper.chart" . }}
+{{ include "cni-metrics-helper.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "cni-metrics-helper.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "cni-metrics-helper.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "cni-metrics-helper.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "cni-metrics-helper.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/stable/cni-metrics-helper/templates/clusterrole.yaml
+++ b/stable/cni-metrics-helper/templates/clusterrole.yaml
@@ -1,0 +1,38 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "cni-metrics-helper.fullname" . }}
+rules:
+  - apiGroups: [""]
+    resources:
+      - nodes
+      - pods
+      - pods/proxy
+      - services
+      - resourcequotas
+      - replicationcontrollers
+      - limitranges
+      - persistentvolumeclaims
+      - persistentvolumes
+      - namespaces
+      - endpoints
+    verbs: ["list", "watch", "get"]
+  - apiGroups: ["extensions"]
+    resources:
+      - daemonsets
+      - deployments
+      - replicasets
+    verbs: ["list", "watch"]
+  - apiGroups: ["apps"]
+    resources:
+      - statefulsets
+    verbs: ["list", "watch"]
+  - apiGroups: ["batch"]
+    resources:
+      - cronjobs
+      - jobs
+    verbs: ["list", "watch"]
+  - apiGroups: ["autoscaling"]
+    resources:
+      - horizontalpodautoscalers
+    verbs: ["list", "watch"]       

--- a/stable/cni-metrics-helper/templates/clusterrolebinding.yaml
+++ b/stable/cni-metrics-helper/templates/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "cni-metrics-helper.fullname" . }}
+  labels:
+{{ include "cni-metrics-helper.labels" . | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "cni-metrics-helper.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "cni-metrics-helper.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}

--- a/stable/cni-metrics-helper/templates/deployment.yaml
+++ b/stable/cni-metrics-helper/templates/deployment.yaml
@@ -1,0 +1,25 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: {{ include "cni-metrics-helper.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    k8s-app: cni-metrics-helper
+spec:
+  selector:
+    matchLabels:
+      k8s-app: cni-metrics-helper
+  template:
+    metadata:
+      labels:
+        k8s-app: cni-metrics-helper
+    spec:
+      containers:
+      - env:
+{{- range $key, $value := .Values.env }}
+        - name: {{ $key }}
+          value: {{ $value | quote }}
+{{- end }}
+        name: cni-metrics-helper
+        image: "{{- if .Values.image.override }}{{- .Values.image.override }}{{- else }}{{- .Values.image.account }}.dkr.ecr.{{- .Values.image.region }}.{{- .Values.image.domain }}/cni-metrics-helper:{{- .Values.image.tag }}{{- end}}"
+      serviceAccountName: {{ template "cni-metrics-helper.serviceAccountName" . }} 

--- a/stable/cni-metrics-helper/templates/serviceaccount.yaml
+++ b/stable/cni-metrics-helper/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "cni-metrics-helper.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- with .Values.serviceAccount.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+  labels:
+{{ include "cni-metrics-helper.labels" . | indent 4 }}
+{{- end -}}

--- a/stable/cni-metrics-helper/values.yaml
+++ b/stable/cni-metrics-helper/values.yaml
@@ -1,0 +1,25 @@
+# This default name override is to maintain backwards compatability with
+# existing naming
+nameOverride: cni-metrics-helper
+
+image:
+  region: us-west-2
+  tag: v1.10.1
+  account: "602401143452"
+  domain: "amazonaws.com"   
+  # Set to use custom image
+  # override: "repo/org/image:tag"
+
+env:
+  USE_CLOUDWATCH: "true"
+
+fullnameOverride: "cni-metrics-helper"
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+  annotations: {}
+    # eks.amazonaws.com/role-arn: arn:aws:iam::AWS_ACCOUNT_ID:role/IAM_ROLE_NAME  


### PR DESCRIPTION
  ## cni-metrics-helper v1.10.1 Automated Chart Sync! 🤖🤖

  ### Release Notes 📝:

  ## v1.10.1

#### Release Notes: 
v1.10.1 removes IMDSv1 dependency from VPC CNI.

* Bug - [Remove IMDSv1 Dependency](https://github.com/aws/amazon-vpc-cni-k8s/pull/1743)(#1743, [@chlunde)](https://github.com/chlunde)


#### To apply this release: 

```
kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/release-1.10/config/master/aws-k8s-cni.yaml
```


#### Verify the update:

```
$ kubectl describe daemonset aws-node -n kube-system | grep Image | cut -d "/" -f 2                                                   
amazon-k8s-cni-init:v1.10.1
amazon-k8s-cni:v1.10.1
```

#### Note: 
Amazon EKS does not yet support IPv6. You can follow progress on this feature by subscribing to the [issue](https://github.com/aws/containers-roadmap/issues/835) for EKS IPv6 support on the containers roadmap. 