### PR TITLE
🥳 aws-load-balancer-controller v2.4.0 Automated Release! 🥑

### DIFF
--- a/stable/aws-load-balancer-controller/Chart.yaml
+++ b/stable/aws-load-balancer-controller/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: aws-load-balancer-controller
 description: AWS Load Balancer Controller Helm chart for Kubernetes
-version: 1.3.3
-appVersion: v2.3.1
+version: 1.4.0
+appVersion: v2.4.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/stable/aws-load-balancer-controller/README.md
+++ b/stable/aws-load-balancer-controller/README.md
@@ -20,13 +20,12 @@ AWS Load Balancer controller manages the following AWS resources
 **Note**: Deployed chart does not receive security updates automatically. You need to manually upgrade to a newer chart.
 
 ## Prerequisites
-- Kubernetes >= 1.16 for ALB
-- Kubernetes >= 1.16 for NLB IP/Instance using Service type NodePort
-- Kubernetes >= v1.20 or EKS >= 1.16 or the following patch releases for Service type `LoadBalancer`
-   - 1.18.18+ for 1.18
-   - 1.19.10+ for 1.19
+- Kubernetes >= 1.19
 - IAM permissions
-- Helm v3 is needed
+- Helm v3
+- Optional dependencies
+  - cert-manager
+  - Prometheus Operator
 
 The controller runs on the worker nodes, so it needs access to the AWS ALB/NLB resources via IAM permissions. The
 IAM permissions can either be setup via IAM roles for ServiceAccount or can be attached directly to the worker node IAM roles.
@@ -76,6 +75,14 @@ If migrating from ALB ingress controller, grant [additional IAM permissions](htt
 kubectl apply -k "github.com/aws/eks-charts/stable/aws-load-balancer-controller//crds?ref=master"
 ```
 - you can run helm upgrade without uninstalling the old chart completely
+
+#### Installing cert-manager
+
+If you are setting `enableCertManager: true` you need to have installed cert-manager and it's CRDs before installing this chart; to install [cert-manager](https://artifacthub.io/packages/helm/cert-manager/cert-manager) follow the installation guide.
+
+#### Installing the Prometheus Operator
+
+If you are setting `serviceMonitor.enabled: true` you need to have installed the Prometheus Operator ServiceMonitor CRD before installing this chart and have the operator running to collect the metrics. The easiest way to do this is to install the [kube-prometheus-stack](https://artifacthub.io/packages/helm/prometheus-community/kube-prometheus-stack) Helm chart using the installation guide.
 
 ## Installing the Chart
 **Note**: You need to uninstall aws-alb-ingress-controller. Please refer to the [upgrade](#Upgrade) section below before you proceed.
@@ -140,6 +147,11 @@ $ helm delete aws-load-balancer-controller -n kube-system
 helm delete aws-load-balancer-controller -n kube-system
 ```
 
+If you setup IAM Roles for ServiceAccount, you can cleanup as follows
+```
+eksctl delete iamserviceaccount --cluster <cluster-name> --namespace kube-system --name aws-load-balancer-controller
+```
+
 ## HA configuration
 Chart release v1.2.0 and later enables high availability configuration by default.
 - The default number of replicas is 2. You can pass`--set replicaCount=1` flag during chart installation to disable this. Due to leader election, only one controller will actively reconcile resources.
@@ -152,65 +164,73 @@ Chart release v1.2.0 and later enables high availability configuration by defaul
 The following tables lists the configurable parameters of the chart and their default values.
 The default values set by the application itself can be confirmed [here](https://kubernetes-sigs.github.io/aws-load-balancer-controller/guide/controller/configurations/).
 
-| Parameter                                   | Description                                                                                              | Default                                                                            |
-| ------------------------------------------- | -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
-| `image.repository`                          | image repository                                                                                         | `602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-load-balancer-controller` |
-| `image.tag`                                 | image tag                                                                                                | `<VERSION>`                                                                        |
-| `image.pullPolicy`                          | image pull policy                                                                                        | `IfNotPresent`                                                                     |
-| `clusterName`                               | Kubernetes cluster name                                                                                  | None                                                                               |
-| `securityContext`                           | Set to security context for pod                                                                          | `{}`                                                                               |
-| `resources`                                 | Controller pod resource requests & limits                                                                | `{}`                                                                               |
-| `priorityClassName`                         | Controller pod priority class                                                                            | system-cluster-critical                                                            |
-| `nodeSelector`                              | Node labels for controller pod assignment                                                                | `{}`                                                                               |
-| `tolerations`                               | Controller pod toleration for taints                                                                     | `{}`                                                                               |
-| `affinity`                                  | Affinity for pod assignment                                                                              | `{}`                                                                               |
-| `podAnnotations`                            | Annotations to add to each pod                                                                           | `{}`                                                                               |
-| `podLabels`                                 | Labels to add to each pod                                                                                | `{}`                                                                               |
-| `rbac.create`                               | if `true`, create and use RBAC resources                                                                 | `true`                                                                             |
-| `serviceAccount.annotations`                | optional annotations to add to service account                                                           | None                                                                               |
-| `serviceAccount.automountServiceAccountToken`                | Automount API credentials for a Service Account                                         | `true`                                                                             |
-| `serviceAccount.create`                     | If `true`, create a new service account                                                                  | `true`                                                                             |
-| `serviceAccount.name`                       | Service account to be used                                                                               | None                                                                               |
-| `terminationGracePeriodSeconds`             | Time period for controller pod to do a graceful shutdown                                                 | 10                                                                                 |
-| `ingressClass`                              | The ingress class to satisfy                                                                             | alb                                                                                |
-| `createIngressClassResource`                | Create ingressClass resource                                                                             | false                                                                              |
-| `region`                                    | The AWS region for the kubernetes cluster                                                                | None                                                                               |
-| `vpcId`                                     | The VPC ID for the Kubernetes cluster                                                                    | None                                                                               |
-| `awsMaxRetries`                             | Maximum retries for AWS APIs                                                                             | None                                                                               |
-| `enablePodReadinessGateInject`              | If enabled, targetHealth readiness gate will get injected to the pod spec for the matching endpoint pods | None                                                                               |
-| `enableShield`                              | Enable Shield addon for ALB                                                                              | None                                                                               |
-| `enableWaf`                                 | Enable WAF addon for ALB                                                                                 | None                                                                               |
-| `enableWafv2`                               | Enable WAF V2 addon for ALB                                                                              | None                                                                               |
-| `ingressMaxConcurrentReconciles`            | Maximum number of concurrently running reconcile loops for ingress                                       | None                                                                               |
-| `logLevel`                                  | Set the controller log level - info, debug                                                               | None                                                                               |
-| `metricsBindAddr`                           | The address the metric endpoint binds to                                                                 | ""                                                                                 |
-| `webhookBindPort`                           | The TCP port the Webhook server binds to                                                                 | None                                                                               |
-| `webhookTLS.caCert`                         | TLS CA certificate for webhook (auto-generated if not provided)                                          | ""                                                                                 |
-| `webhookTLS.cert`                           | TLS certificate for webhook (auto-generated if not provided)                                             | ""                                                                                 |
-| `webhookTLS.key`                            | TLS private key for webhook (auto-generated if not provided)                                             | ""                                                                                 |
-| `keepTLSSecret`                             | Reuse existing TLS Secret during chart upgrade                                                           | `false`                                                                            |
-| `serviceAnnotations`                        | Annotations to be added to the provisioned webhook service resource                                      | `{}`                                                                               |
-| `serviceMaxConcurrentReconciles`            | Maximum number of concurrently running reconcile loops for service                                       | None                                                                               |
-| `targetgroupbindingMaxConcurrentReconciles` | Maximum number of concurrently running reconcile loops for targetGroupBinding                            | None                                                                               |
-| `targetgroupbindingMaxExponentialBackoffDelay` | Maximum duration of exponential backoff for targetGroupBinding reconcile failures                     | None                                                                               |
-| `syncPeriod`                                | Period at which the controller forces the repopulation of its local object stores                        | None                                                                               |
-| `watchNamespace`                            | Namespace the controller watches for updates to Kubernetes objects, If empty, all namespaces are watched | None                                                                               |
-| `disableIngressClassAnnotation`             | Disables the usage of kubernetes.io/ingress.class annotation                                             | None                                                                               |
-| `disableIngressGroupNameAnnotation`         | Disables the usage of alb.ingress.kubernetes.io/group.name annotation                                    | None                                                                               |
-| `defaultSSLPolicy`                          | Specifies the default SSL policy to use for HTTPS or TLS listeners                                       | None                                                                               |
-| `externalManagedTags`                       | Specifies the list of tag keys on AWS resources that are managed externally                              | `[]`                                                                               |
-| `livenessProbe`                             | Liveness probe settings for the controller                                                               | (see `values.yaml`)                                                                |
-| `env`                                       | Environment variables to set for aws-load-balancer-controller pod                                        | None                                                                               |
-| `hostNetwork`                               | If `true`, use hostNetwork                                                                               | `false`                                                                            |
-| `dnsPolicy`                                 | Set dnsPolicy if required                                                                                | `ClusterFirst`                                                                     |
-| `extraVolumeMounts`                         | Extra volume mounts for the pod                                                                          | `[]`                                                                               |
-| `extraVolumes`                              | Extra volumes for the pod                                                                                | `[]`                                                                               |
-| `defaultTags`                               | Default tags to apply to all AWS resources managed by this controller                                    | `{}`                                                                               |
-| `replicaCount`                              | Number of controller pods to run, only one will be active due to leader election                         | `2`                                                                                |
-| `podDisruptionBudget`                       | Limit the disruption for controller pods. Require at least 2 controller replicas and 3 worker nodes      | `{}`                                                                               |
-| `updateStrategy`                            | Defines the update strategy for the deployment                                                           | `{}`                                                                               |
-| `enableCertManager`                         | If enabled, cert-manager issues the webhook certificates instead of the helm template                    | `false`                                                                            |
-| `enableEndpointSlices`                      | If enabled, controller uses k8s EndpointSlices instead of Endpoints for IP targets                       | `false`                                                                            |
-| `enableBackendSecurityGroup`                | If enabled, controller uses shared security group for backend traffic                                    | `true`                                                                             |
-| `backendSecurityGroup`                      | Backend security group to use instead of auto created one if the feature is enabled                      | ``                                                                                 |
-| `disableRestrictedSecurityGroupRules`       | If disabled, controller will not specify port range restriction in the backend security group rules      | `false`                                                                            |
+| Parameter                                      | Description                                                                                              | Default                                                                            |
+| ---------------------------------------------- | -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `image.repository`                             | image repository                                                                                         | `602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-load-balancer-controller` |
+| `image.tag`                                    | image tag                                                                                                | `<VERSION>`                                                                        |
+| `image.pullPolicy`                             | image pull policy                                                                                        | `IfNotPresent`                                                                     |
+| `clusterName`                                  | Kubernetes cluster name                                                                                  | None                                                                               |
+| `securityContext`                              | Set to security context for pod                                                                          | `{}`                                                                               |
+| `resources`                                    | Controller pod resource requests & limits                                                                | `{}`                                                                               |
+| `priorityClassName`                            | Controller pod priority class                                                                            | system-cluster-critical                                                            |
+| `nodeSelector`                                 | Node labels for controller pod assignment                                                                | `{}`                                                                               |
+| `tolerations`                                  | Controller pod toleration for taints                                                                     | `{}`                                                                               |
+| `affinity`                                     | Affinity for pod assignment                                                                              | `{}`                                                                               |
+| `podAnnotations`                               | Annotations to add to each pod                                                                           | `{}`                                                                               |
+| `podLabels`                                    | Labels to add to each pod                                                                                | `{}`                                                                               |
+| `rbac.create`                                  | if `true`, create and use RBAC resources                                                                 | `true`                                                                             |
+| `serviceAccount.annotations`                   | optional annotations to add to service account                                                           | None                                                                               |
+| `serviceAccount.automountServiceAccountToken`  | Automount API credentials for a Service Account                                                          | `true`                                                                             |
+| `serviceAccount.create`                        | If `true`, create a new service account                                                                  | `true`                                                                             |
+| `serviceAccount.name`                          | Service account to be used                                                                               | None                                                                               |
+| `terminationGracePeriodSeconds`                | Time period for controller pod to do a graceful shutdown                                                 | 10                                                                                 |
+| `ingressClass`                                 | The ingress class to satisfy                                                                             | alb                                                                                |
+| `createIngressClassResource`                   | Create ingressClass resource                                                                             | true                                                                               |
+| `ingressClassParams.name`                      | IngressClassParams resource's name, default to the aws load balancer controller's name                   | None                                                                               |
+| `ingressClassParams.create`                    | If `true`, create a new ingressClassParams                                                               | true                                                                               |
+| `ingressClassParams.spec`                      | IngressClassParams defined ingress specifications                                                        | {}                                                                                 |
+| `region`                                       | The AWS region for the kubernetes cluster                                                                | None                                                                               |
+| `vpcId`                                        | The VPC ID for the Kubernetes cluster                                                                    | None                                                                               |
+| `awsMaxRetries`                                | Maximum retries for AWS APIs                                                                             | None                                                                               |
+| `enablePodReadinessGateInject`                 | If enabled, targetHealth readiness gate will get injected to the pod spec for the matching endpoint pods | None                                                                               |
+| `enableShield`                                 | Enable Shield addon for ALB                                                                              | None                                                                               |
+| `enableWaf`                                    | Enable WAF addon for ALB                                                                                 | None                                                                               |
+| `enableWafv2`                                  | Enable WAF V2 addon for ALB                                                                              | None                                                                               |
+| `ingressMaxConcurrentReconciles`               | Maximum number of concurrently running reconcile loops for ingress                                       | None                                                                               |
+| `logLevel`                                     | Set the controller log level - info, debug                                                               | None                                                                               |
+| `metricsBindAddr`                              | The address the metric endpoint binds to                                                                 | ""                                                                                 |
+| `webhookBindPort`                              | The TCP port the Webhook server binds to                                                                 | None                                                                               |
+| `webhookTLS.caCert`                            | TLS CA certificate for webhook (auto-generated if not provided)                                          | ""                                                                                 |
+| `webhookTLS.cert`                              | TLS certificate for webhook (auto-generated if not provided)                                             | ""                                                                                 |
+| `webhookTLS.key`                               | TLS private key for webhook (auto-generated if not provided)                                             | ""                                                                                 |
+| `keepTLSSecret`                                | Reuse existing TLS Secret during chart upgrade                                                           | `true`                                                                             |
+| `serviceAnnotations`                           | Annotations to be added to the provisioned webhook service resource                                      | `{}`                                                                               |
+| `serviceMaxConcurrentReconciles`               | Maximum number of concurrently running reconcile loops for service                                       | None                                                                               |
+| `targetgroupbindingMaxConcurrentReconciles`    | Maximum number of concurrently running reconcile loops for targetGroupBinding                            | None                                                                               |
+| `targetgroupbindingMaxExponentialBackoffDelay` | Maximum duration of exponential backoff for targetGroupBinding reconcile failures                        | None                                                                               |
+| `syncPeriod`                                   | Period at which the controller forces the repopulation of its local object stores                        | None                                                                               |
+| `watchNamespace`                               | Namespace the controller watches for updates to Kubernetes objects, If empty, all namespaces are watched | None                                                                               |
+| `disableIngressClassAnnotation`                | Disables the usage of kubernetes.io/ingress.class annotation                                             | None                                                                               |
+| `disableIngressGroupNameAnnotation`            | Disables the usage of alb.ingress.kubernetes.io/group.name annotation                                    | None                                                                               |
+| `defaultSSLPolicy`                             | Specifies the default SSL policy to use for HTTPS or TLS listeners                                       | None                                                                               |
+| `externalManagedTags`                          | Specifies the list of tag keys on AWS resources that are managed externally                              | `[]`                                                                               |
+| `livenessProbe`                                | Liveness probe settings for the controller                                                               | (see `values.yaml`)                                                                |
+| `env`                                          | Environment variables to set for aws-load-balancer-controller pod                                        | None                                                                               |
+| `hostNetwork`                                  | If `true`, use hostNetwork                                                                               | `false`                                                                            |
+| `dnsPolicy`                                    | Set dnsPolicy if required                                                                                | `ClusterFirst`                                                                     |
+| `extraVolumeMounts`                            | Extra volume mounts for the pod                                                                          | `[]`                                                                               |
+| `extraVolumes`                                 | Extra volumes for the pod                                                                                | `[]`                                                                               |
+| `defaultTags`                                  | Default tags to apply to all AWS resources managed by this controller                                    | `{}`                                                                               |
+| `replicaCount`                                 | Number of controller pods to run, only one will be active due to leader election                         | `2`                                                                                |
+| `podDisruptionBudget`                          | Limit the disruption for controller pods. Require at least 2 controller replicas and 3 worker nodes      | `{}`                                                                               |
+| `updateStrategy`                               | Defines the update strategy for the deployment                                                           | `{}`                                                                               |
+| `enableCertManager`                            | If enabled, cert-manager issues the webhook certificates instead of the helm template, requires cert-manager and it's CRDs to be installed | `false`                                          |
+| `enableEndpointSlices`                         | If enabled, controller uses k8s EndpointSlices instead of Endpoints for IP targets                       | `false`                                                                            |
+| `enableBackendSecurityGroup`                   | If enabled, controller uses shared security group for backend traffic                                    | `true`                                                                             |
+| `backendSecurityGroup`                         | Backend security group to use instead of auto created one if the feature is enabled                      | ``                                                                                 |
+| `disableRestrictedSecurityGroupRules`          | If disabled, controller will not specify port range restriction in the backend security group rules      | `false`                                                                            |
+| `objectSelector.matchExpressions`              | Webhook configuration to select specific pods by specifying the expression to be matched                 | None                                                                               |
+| `objectSelector.matchLabels`                   | Webhook configuration to select specific pods by specifying the key value label pair to be matched       | None                                                                               |
+| `serviceMonitor.enabled`                       | Specifies whether a service monitor should be created, requires the ServiceMonitor CRD to be installed   | `false`                                                                            |
+| `serviceMonitor.additionalLabels`              | Labels to add to the service account                                                                     | `{}`                                                                               |
+| `serviceMonitor.interval`                      | Prometheus scrape interval                                                                               | `1m`                                                                               |

--- a/stable/aws-load-balancer-controller/templates/_helpers.tpl
+++ b/stable/aws-load-balancer-controller/templates/_helpers.tpl
@@ -73,11 +73,26 @@ Create the name of the service account to use
 {{- end -}}
 
 {{/*
+Create the name of the webhook service
+*/}}
+{{- define "aws-load-balancer-controller.webhookService" -}}
+{{- printf "%s-webhook-service" (include "aws-load-balancer-controller.namePrefix" .) -}}
+{{- end -}}
+
+{{/*
+Create the name of the webhook cert secret
+*/}}
+{{- define "aws-load-balancer-controller.webhookCertSecret" -}}
+{{- printf "%s-tls" (include "aws-load-balancer-controller.namePrefix" .) -}}
+{{- end -}}
+
+{{/*
 Generate certificates for webhook
 */}}
-{{- define "aws-load-balancer-controller.webhook-certs" -}}
-{{- $namePrefix := ( include "aws-load-balancer-controller.namePrefix" . ) -}}
-{{- $secret := lookup "v1" "Secret" .Release.Namespace (printf "%s-tls" $namePrefix) -}}
+{{- define "aws-load-balancer-controller.webhookCerts" -}}
+{{- $serviceName := (include "aws-load-balancer-controller.webhookService" .) -}}
+{{- $secretName := (include "aws-load-balancer-controller.webhookCertSecret" .) -}}
+{{- $secret := lookup "v1" "Secret" .Release.Namespace $secretName -}}
 {{- if (and .Values.webhookTLS.caCert .Values.webhookTLS.cert .Values.webhookTLS.key) -}}
 caCert: {{ .Values.webhookTLS.caCert | b64enc }}
 clientCert: {{ .Values.webhookTLS.cert | b64enc }}
@@ -87,9 +102,9 @@ caCert: {{ index $secret.data "ca.crt" }}
 clientCert: {{ index $secret.data "tls.crt" }}
 clientKey: {{ index $secret.data "tls.key" }}
 {{- else -}}
-{{- $altNames := list ( printf "%s-%s.%s" $namePrefix "webhook-service" .Release.Namespace ) ( printf "%s-%s.%s.svc" $namePrefix "webhook-service" .Release.Namespace ) -}}
+{{- $altNames := list (printf "%s.%s" $serviceName .Release.Namespace) (printf "%s.%s.svc" $serviceName .Release.Namespace) (printf "%s.%s.svc.cluster.local" $serviceName .Release.Namespace) -}}
 {{- $ca := genCA "aws-load-balancer-controller-ca" 3650 -}}
-{{- $cert := genSignedCert ( include "aws-load-balancer-controller.fullname" . ) nil $altNames 3650 $ca -}}
+{{- $cert := genSignedCert (include "aws-load-balancer-controller.fullname" .) nil $altNames 3650 $ca -}}
 caCert: {{ $ca.Cert | b64enc }}
 clientCert: {{ $cert.Cert | b64enc }}
 clientKey: {{ $cert.Key | b64enc }}
@@ -99,6 +114,13 @@ clientKey: {{ $cert.Key | b64enc }}
 {{/*
 Convert map to comma separated key=value string
 */}}
-{{- define "aws-load-balancer-controller.convert-map-to-csv" -}}
+{{- define "aws-load-balancer-controller.convertMapToCsv" -}}
 {{- range $key, $value := . -}} {{ $key }}={{ $value }}, {{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the ingressClassParams
+*/}}
+{{- define "aws-load-balancer-controller.ingressClassParamsName" -}}
+{{ default .Values.ingressClass .Values.ingressClassParams.name }}
 {{- end -}}

--- a/stable/aws-load-balancer-controller/templates/deployment.yaml
+++ b/stable/aws-load-balancer-controller/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
       - name: cert
         secret:
           defaultMode: 420
-          secretName: {{ template "aws-load-balancer-controller.namePrefix" . }}-tls
+          secretName: {{ template "aws-load-balancer-controller.webhookCertSecret" . }}
       {{- with .Values.extraVolumes }}
       {{ toYaml . | nindent 6 }}
       {{- end }}
@@ -120,7 +120,7 @@ spec:
         - --external-managed-tags={{ join "," .Values.externalManagedTags }}
         {{- end }}
         {{- if .Values.defaultTags }}
-        - --default-tags={{ include "aws-load-balancer-controller.convert-map-to-csv" .Values.defaultTags | trimSuffix "," }}
+        - --default-tags={{ include "aws-load-balancer-controller.convertMapToCsv" .Values.defaultTags | trimSuffix "," }}
         {{- end }}
         {{- if kindIs "bool" .Values.enableEndpointSlices }}
         - --enable-endpoint-slices={{ .Values.enableEndpointSlices }}

--- a/stable/aws-load-balancer-controller/templates/ingressclass.yaml
+++ b/stable/aws-load-balancer-controller/templates/ingressclass.yaml
@@ -7,4 +7,10 @@ metadata:
     {{- include "aws-load-balancer-controller.labels" . | nindent 4 }}
 spec:
   controller: ingress.k8s.aws/alb
+  {{- if or .Values.ingressClassParams.create .Values.ingressClassParams.name }}
+  parameters:
+    apiGroup: elbv2.k8s.aws
+    kind: IngressClassParams
+    name: {{ include "aws-load-balancer-controller.ingressClassParamsName" . }}
+  {{- end }}
 {{- end }}

--- a/stable/aws-load-balancer-controller/templates/ingressclassparams.yaml
+++ b/stable/aws-load-balancer-controller/templates/ingressclassparams.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.ingressClassParams.create }}
+apiVersion: elbv2.k8s.aws/v1beta1
+kind: IngressClassParams
+metadata:
+  name: {{ include "aws-load-balancer-controller.ingressClassParamsName" . }}
+  labels:
+    {{- include "aws-load-balancer-controller.labels" . | nindent 4 }}
+{{- if .Values.ingressClassParams.spec }}
+spec:
+  {{ toYaml .Values.ingressClassParams.spec | nindent 2}}
+{{- end }}
+{{- end }}

--- a/stable/aws-load-balancer-controller/templates/service.yaml
+++ b/stable/aws-load-balancer-controller/templates/service.yaml
@@ -1,17 +1,41 @@
+{{- if.Values.serviceMonitor.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "aws-load-balancer-controller.namePrefix" . }}-webhook-service
+  name: {{ template "aws-load-balancer-controller.fullname" . }}
   namespace: {{ .Release.Namespace }}
   {{- with .Values.serviceAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
-{{ include "aws-load-balancer-controller.labels" . | indent 4 }}
+    {{- include "aws-load-balancer-controller.labels" . | nindent 4 }}
+spec:
+  ports:
+    - port: 8080
+      name: metrics-server
+      targetPort: metrics-server
+  selector:
+    {{- include "aws-load-balancer-controller.selectorLabels" . | nindent 4 }}
+---
+{{- end }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "aws-load-balancer-controller.webhookService" . }}
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.serviceAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "aws-load-balancer-controller.labels" . | nindent 4 }}
+    app.kubernetes.io/component: webhook
+    prometheus.io/service-monitor: "false"
 spec:
   ports:
   - port: 443
+    name: webhook-server
     targetPort: webhook-server
   selector:
     {{- include "aws-load-balancer-controller.selectorLabels" . | nindent 4 }}

--- a/stable/aws-load-balancer-controller/templates/servicemonitor.yaml
+++ b/stable/aws-load-balancer-controller/templates/servicemonitor.yaml
@@ -1,0 +1,30 @@
+{{- if.Values.serviceMonitor.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "aws-load-balancer-controller.fullname" . }}
+  labels:
+    {{- include "aws-load-balancer-controller.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  jobLabel: {{ .Release.Name }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "aws-load-balancer-controller.selectorLabels" . | nindent 6 }}
+    matchExpressions:
+      - key: prometheus.io/service-monitor
+        operator: NotIn
+        values:
+          - "false"
+  endpoints:
+    - port: metrics-server
+      path: /metrics
+      {{- with .Values.serviceMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+{{- end -}}

--- a/stable/aws-load-balancer-controller/templates/webhook.yaml
+++ b/stable/aws-load-balancer-controller/templates/webhook.yaml
@@ -1,10 +1,6 @@
-{{ $tls := fromYaml ( include "aws-load-balancer-controller.webhook-certs" . ) }}
+{{ $tls := fromYaml ( include "aws-load-balancer-controller.webhookCerts" . ) }}
 ---
-{{- if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1" }}
 apiVersion: admissionregistration.k8s.io/v1
-{{- else }}
-apiVersion: admissionregistration.k8s.io/v1beta1
-{{- end }}
 kind: MutatingWebhookConfiguration
 metadata:
 {{- if $.Values.enableCertManager }}
@@ -18,7 +14,7 @@ webhooks:
 - clientConfig:
     caBundle: {{ if not $.Values.enableCertManager -}}{{ $tls.caCert }}{{- else -}}Cg=={{ end }}
     service:
-      name: {{ template "aws-load-balancer-controller.namePrefix" . }}-webhook-service
+      name: {{ template "aws-load-balancer-controller.webhookService" . }}
       namespace: {{ $.Release.Namespace }}
       path: /mutate-v1-pod
   failurePolicy: Fail
@@ -37,6 +33,13 @@ webhooks:
       operator: NotIn
       values:
       - {{ include "aws-load-balancer-controller.name" . }}
+    {{- if .Values.objectSelector.matchExpressions }}
+    {{- toYaml .Values.objectSelector.matchExpressions | nindent 4 }}
+    {{- end }}
+    {{- if .Values.objectSelector.matchLabels }}
+    matchLabels:
+    {{- toYaml .Values.objectSelector.matchLabels | nindent 6 }}
+    {{- end }}
   rules:
   - apiGroups:
     - ""
@@ -50,7 +53,7 @@ webhooks:
 - clientConfig:
     caBundle: {{ if not $.Values.enableCertManager -}}{{ $tls.caCert }}{{- else -}}Cg=={{ end }}
     service:
-      name: {{ template "aws-load-balancer-controller.namePrefix" . }}-webhook-service
+      name: {{ template "aws-load-balancer-controller.webhookService" . }}
       namespace: {{ $.Release.Namespace }}
       path: /mutate-elbv2-k8s-aws-v1beta1-targetgroupbinding
   failurePolicy: Fail
@@ -69,11 +72,7 @@ webhooks:
     - targetgroupbindings
   sideEffects: None
 ---
-{{- if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1" }}
 apiVersion: admissionregistration.k8s.io/v1
-{{- else }}
-apiVersion: admissionregistration.k8s.io/v1beta1
-{{- end }}
 kind: ValidatingWebhookConfiguration
 metadata:
 {{- if $.Values.enableCertManager }}
@@ -87,7 +86,7 @@ webhooks:
 - clientConfig:
     caBundle: {{ if not $.Values.enableCertManager -}}{{ $tls.caCert }}{{- else -}}Cg=={{ end }}
     service:
-      name: {{ template "aws-load-balancer-controller.namePrefix" . }}-webhook-service
+      name: {{ template "aws-load-balancer-controller.webhookService" . }}
       namespace: {{ $.Release.Namespace }}
       path: /validate-elbv2-k8s-aws-v1beta1-targetgroupbinding
   failurePolicy: Fail
@@ -108,9 +107,9 @@ webhooks:
 - clientConfig:
     caBundle: {{ if not $.Values.enableCertManager -}}{{ $tls.caCert }}{{- else -}}Cg=={{ end }}
     service:
-      name: {{ template "aws-load-balancer-controller.namePrefix" . }}-webhook-service
+      name: {{ template "aws-load-balancer-controller.webhookService" . }}
       namespace: {{ $.Release.Namespace }}
-      path: /validate-networking-v1beta1-ingress
+      path: /validate-networking-v1-ingress
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: vingress.elbv2.k8s.aws
@@ -120,7 +119,7 @@ webhooks:
   - apiGroups:
     - networking.k8s.io
     apiVersions:
-    - v1beta1
+    - v1
     operations:
     - CREATE
     - UPDATE
@@ -132,7 +131,7 @@ webhooks:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "aws-load-balancer-controller.namePrefix" . }}-tls
+  name: {{ template "aws-load-balancer-controller.webhookCertSecret" . }}
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "aws-load-balancer-controller.labels" . | indent 4 }}
@@ -155,12 +154,12 @@ metadata:
 {{ include "aws-load-balancer-controller.labels" . | indent 4 }}
 spec:
   dnsNames:
-  - {{ template "aws-load-balancer-controller.namePrefix" . }}-webhook-service.{{ .Release.Namespace }}.svc
-  - {{ template "aws-load-balancer-controller.namePrefix" . }}-webhook-service.{{ .Release.Namespace }}.svc.cluster.local
+  - {{ template "aws-load-balancer-controller.webhookService" . }}.{{ .Release.Namespace }}.svc
+  - {{ template "aws-load-balancer-controller.webhookService" . }}.{{ .Release.Namespace }}.svc.cluster.local
   issuerRef:
     kind: Issuer
     name: {{ template "aws-load-balancer-controller.namePrefix" . }}-selfsigned-issuer
-  secretName: {{ template "aws-load-balancer-controller.namePrefix" . }}-tls
+  secretName: {{ template "aws-load-balancer-controller.webhookCertSecret" . }}
 ---
 {{- if .Capabilities.APIVersions.Has "cert-manager.io/v1" }}
 apiVersion: cert-manager.io/v1

--- a/stable/aws-load-balancer-controller/values.yaml
+++ b/stable/aws-load-balancer-controller/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 2
 
 image:
   repository: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-load-balancer-controller
-  tag: v2.3.1
+  tag: v2.4.0
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -87,9 +87,25 @@ enableCertManager: false
 # ingresses without ingress class annotation and ingresses of type alb
 ingressClass: alb
 
+# ingressClassParams specify the IngressCLassParams that enforce settings for a set of Ingresses when using with ingress Controller.
+ingressClassParams:
+  create: true
+  # The name of ingressClassParams resource will be referred in ingressClass
+  name:
+  spec: {}
+    # You always can set specifications in `helm install` command through `--set` or `--set-string`
+    # If you do want to specify specifications in values.yaml, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'spec:'.
+    # namespaceSelector:
+    #   matchLabels:
+    # group:
+    # scheme:
+    # ipAddressType:
+    # tags:
+
 # To use IngressClass resource instead of annotation, before you need to install the IngressClass resource pointing to controller.
 # If specified as true, the IngressClass resource will be created.
-createIngressClassResource: false
+createIngressClassResource: true
 
 # The AWS region for the kubernetes cluster. Set to use KIAM or kube2iam for example.
 region:
@@ -134,7 +150,7 @@ webhookTLS:
   key:
 
 # keepTLSSecret specifies whether to reuse existing TLS secret for chart upgrade
-keepTLSSecret: false
+keepTLSSecret: true
 
 # Maximum number of concurrently running reconcile loops for service (default 3)
 serviceMaxConcurrentReconciles:
@@ -232,3 +248,21 @@ backendSecurityGroup:
 
 # disableRestrictedSecurityGroupRules specifies whether to disable creating port-range restricted security group rules for traffic
 disableRestrictedSecurityGroupRules:
+
+# objectSelector for webhook
+objectSelector:
+  matchExpressions:
+  # - key: <key>
+  #   operator: <operator>
+  #   values:
+  #   - <value>
+  matchLabels:
+  #   key: value
+
+serviceMonitor:
+  # Specifies whether a service monitor should be created
+  enabled: false
+  # Labels to add to the service account
+  additionalLabels: {}
+  # Prometheus scrape interval
+  interval: 1m


### PR DESCRIPTION
  ## aws-load-balancer-controller v2.4.0 Automated Chart Sync! 🤖🤖

  ### Release Notes 📝:

  ## v2.4.0 (requires Kubernetes 1.19+)
## [Documentation](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.4/)
Image: docker.io/amazon/aws-alb-ingress-controller:v2.4.0

Thanks to all our contributors! 😊

## Note
This release uses the new Ingress API version networking.k8s.io/v1 available in kubernetes 1.19 and later releases. As a result, the v2.4.0 and later releases of the `aws-load-balancer-controller` will not support kubernetes 1.18 and older versions. If you are running the older k8s version, you can either upgrade your cluster or use the v2.3.x version of the controller.   

**IMPORTANT** If you are upgrading the controller from a prior version to v2.4.0, please apply the entire manifest or use helm due to the webhook changes.

For convenience, the v2.4.0 release manifest and the helm chart creates an `IngressClass` resource named `alb` by default.

## What's new
1. Support for Ingress API version networking.k8s.io/v1
2. Support for service `spec.loadBalancerClass`
3. Option to disable security group rules management for NLB
4. Merge tags between kubernetes ingress and services
5. Helm chart create IngressClass and IngressClassParams by default
6. Add servicemonitor to helm chart
7. Helm chart `keepTLSSecret` is true by default
8. Provide a new feature gate `ServiceTypeLoadBalancerOnly` which can optionally limit the controller to service of type `LoadBalancer`

## Bug fixes
1. Fix potentially slow resource reconciliation by caching AWS shield subscription state to mitigate API throttling issues
2. Add default tags to the backend Security Group
3. Ignore invalid ARN error while deleting TargetGroupBinding
4. Documentation fixes

## Changelog since v2.3.1
* doc updates for v2.4.0 ([#2506](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2506), @kishorj)
* change IngressClassParams default name to alb ([#2508](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2508), @kishorj)
* Helm chart for v2.4.0 release ([#2503](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2503), @kishorj)
* Upgrade aws-sdk-go to 1.42.27 (#2500, @johngmyers) 
* Add an option to disable SG rules management for NLB ([#2481](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2481), @kishorj)
* make keepTLSSecret true by default ([#2483](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2483), @kishorj)
* add support for loadBalancerClass ([#2489](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2489), @kishorj)
* add documentation for manage-backend-security-group-rules ([#2486](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2486), @kishorj)
* fix typo in annotations doc ([#2482](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2482), @kishorj)
* Adding support of ingressClassParams in helm charts ([#2478](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2478), @haouc)
* Merge tags from alb.ingress.kubernetes.io/tags ([#2480](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2480), @oliviassss)
* feat(chart): add servicemonitor ([#2335](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2335), @stevehipwell)
* Fetch aws-load-balancer-controller logs before deleting ([#2436](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2436), @cgchinmay)
* check invalid TG ARN when deleting TGB(#2454, @oliviassss )
* Upgrade echoserver to 2.5 (#2452, @johngmyers)
* Format AWS policy JSON document for consistency ([#2447](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2447), @orsenthil)
* Add default tags to backend SG ([#2425](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2425), @kishorj)
* helm: Remove unnecessary admissionregistration.k8s.io/v1beta1 ([#2443](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2443), @johngmyers)
* helm: Create IngressClass by default ([#2442](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2442), @johngmyers)
* Add a separate example for dualstack ALB (#2445, @kishorj)
* Update Ingress APIVersion to networking.k8s.io/v1 ([#2433](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2433), @johngmyers)
* e2e: Use Helm chart from the commit ([#2435](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2435), @johngmyers)
* updated Ingress API version in Documentation example ([#2429](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2429), @NIKU-SINGH)
* e2e test helper script ([#2246](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2246), @cgchinmay)
* Add workflow to auto sync helm chart to eks-charts ([#2418](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2418), @oliviassss)
* Typo ([#2416](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2416), @stensonb)
* Enable setting custom objectSelector for webhook ([#2407](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2407), @Shreya027)
* cache AWS shield subscription state for 2 hour ([#2408](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2408), @M00nF1sh)


## ECR images
- 013241004608.dkr.ecr.us-gov-west-1.amazonaws.com/amazon/aws-load-balancer-controller:v2.4.0
- 151742754352.dkr.ecr.us-gov-east-1.amazonaws.com/amazon/aws-load-balancer-controller:v2.4.0
- 558608220178.dkr.ecr.me-south-1.amazonaws.com/amazon/aws-load-balancer-controller:v2.4.0
- 590381155156.dkr.ecr.eu-south-1.amazonaws.com/amazon/aws-load-balancer-controller:v2.4.0
- 602401143452.dkr.ecr.ap-northeast-1.amazonaws.com/amazon/aws-load-balancer-controller:v2.4.0
- 602401143452.dkr.ecr.ap-northeast-2.amazonaws.com/amazon/aws-load-balancer-controller:v2.4.0
- 602401143452.dkr.ecr.ap-northeast-3.amazonaws.com/amazon/aws-load-balancer-controller:v2.4.0
- 602401143452.dkr.ecr.ap-south-1.amazonaws.com/amazon/aws-load-balancer-controller:v2.4.0
- 602401143452.dkr.ecr.ap-southeast-1.amazonaws.com/amazon/aws-load-balancer-controller:v2.4.0
- 602401143452.dkr.ecr.ap-southeast-2.amazonaws.com/amazon/aws-load-balancer-controller:v2.4.0
- 602401143452.dkr.ecr.ca-central-1.amazonaws.com/amazon/aws-load-balancer-controller:v2.4.0
- 602401143452.dkr.ecr.eu-central-1.amazonaws.com/amazon/aws-load-balancer-controller:v2.4.0
- 602401143452.dkr.ecr.eu-north-1.amazonaws.com/amazon/aws-load-balancer-controller:v2.4.0
- 602401143452.dkr.ecr.eu-west-1.amazonaws.com/amazon/aws-load-balancer-controller:v2.4.0
- 602401143452.dkr.ecr.eu-west-2.amazonaws.com/amazon/aws-load-balancer-controller:v2.4.0
- 602401143452.dkr.ecr.eu-west-3.amazonaws.com/amazon/aws-load-balancer-controller:v2.4.0
- 602401143452.dkr.ecr.sa-east-1.amazonaws.com/amazon/aws-load-balancer-controller:v2.4.0
- 602401143452.dkr.ecr.us-east-1.amazonaws.com/amazon/aws-load-balancer-controller:v2.4.0
- 602401143452.dkr.ecr.us-east-2.amazonaws.com/amazon/aws-load-balancer-controller:v2.4.0
- 602401143452.dkr.ecr.us-west-1.amazonaws.com/amazon/aws-load-balancer-controller:v2.4.0
- 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-load-balancer-controller:v2.4.0
- 800184023465.dkr.ecr.ap-east-1.amazonaws.com/amazon/aws-load-balancer-controller:v2.4.0
- 877085696533.dkr.ecr.af-south-1.amazonaws.com/amazon/aws-load-balancer-controller:v2.4.0
- 918309763551.dkr.ecr.cn-north-1.amazonaws.com.cn/amazon/aws-load-balancer-controller:v2.4.0
- 961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon/aws-load-balancer-controller:v2.4.0