### PR TITLE
🥳 aws-load-balancer-controller v2.5.4 Automated Release! 🥑

### DIFF
--- a/stable/aws-load-balancer-controller/Chart.yaml
+++ b/stable/aws-load-balancer-controller/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: aws-load-balancer-controller
 description: AWS Load Balancer Controller Helm chart for Kubernetes
-version: 1.5.3
-appVersion: v2.5.2
+version: 1.5.5
+appVersion: v2.5.4
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/stable/aws-load-balancer-controller/README.md
+++ b/stable/aws-load-balancer-controller/README.md
@@ -82,6 +82,8 @@ kubectl apply -k "github.com/aws/eks-charts/stable/aws-load-balancer-controller/
 
 If you are setting `enableCertManager: true` you need to have installed cert-manager and it's CRDs before installing this chart; to install [cert-manager](https://artifacthub.io/packages/helm/cert-manager/cert-manager) follow the installation guide.
 
+The controller helm chart requires the cert-manager with apiVersion `cert-manager.io/v1`.
+
 Set `cluster.dnsDomain` (default: `cluster.local`) to the actual DNS domain of your cluster to include the FQDN in requested TLS certificates.
 
 #### Installing the Prometheus Operator

--- a/stable/aws-load-balancer-controller/templates/pdb.yaml
+++ b/stable/aws-load-balancer-controller/templates/pdb.yaml
@@ -1,9 +1,5 @@
 {{- if and .Values.podDisruptionBudget (gt (int .Values.replicaCount) 1) }}
-{{- if .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" }}
 apiVersion: policy/v1
-{{- else }}
-apiVersion: policy/v1beta1
-{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "aws-load-balancer-controller.fullname" . }}

--- a/stable/aws-load-balancer-controller/templates/webhook.yaml
+++ b/stable/aws-load-balancer-controller/templates/webhook.yaml
@@ -212,11 +212,7 @@ data:
   tls.crt: {{ $tls.clientCert }}
   tls.key: {{ $tls.clientKey }}
 {{- else }}
-{{- if .Capabilities.APIVersions.Has "cert-manager.io/v1" }}
 apiVersion: cert-manager.io/v1
-{{- else }}
-apiVersion: cert-manager.io/v1alpha2
-{{- end }}
 kind: Certificate
 metadata:
   name: {{ template "aws-load-balancer-controller.namePrefix" . }}-serving-cert
@@ -232,11 +228,7 @@ spec:
     name: {{ template "aws-load-balancer-controller.namePrefix" . }}-selfsigned-issuer
   secretName: {{ template "aws-load-balancer-controller.webhookCertSecret" . }}
 ---
-{{- if .Capabilities.APIVersions.Has "cert-manager.io/v1" }}
 apiVersion: cert-manager.io/v1
-{{- else }}
-apiVersion: cert-manager.io/v1alpha2
-{{- end }}
 kind: Issuer
 metadata:
   name: {{ template "aws-load-balancer-controller.namePrefix" . }}-selfsigned-issuer

--- a/stable/aws-load-balancer-controller/test.yaml
+++ b/stable/aws-load-balancer-controller/test.yaml
@@ -6,7 +6,7 @@ replicaCount: 2
 
 image:
   repository: public.ecr.aws/eks/aws-load-balancer-controller
-  tag: v2.5.2
+  tag: v2.5.4
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/stable/aws-load-balancer-controller/values.yaml
+++ b/stable/aws-load-balancer-controller/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 2
 
 image:
   repository: public.ecr.aws/eks/aws-load-balancer-controller
-  tag: v2.5.2
+  tag: v2.5.4
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -215,7 +215,7 @@ targetgroupbindingMaxConcurrentReconciles:
 # Maximum duration of exponential backoff for targetGroupBinding reconcile failures
 targetgroupbindingMaxExponentialBackoffDelay:
 
-# Period at which the controller forces the repopulation of its local object stores. (default 1h0m0s)
+# Period at which the controller forces the repopulation of its local object stores. (default 10h0m0s)
 syncPeriod:
 
 # Namespace the controller watches for updates to Kubernetes objects, If empty, all namespaces are watched.


### PR DESCRIPTION
  ## aws-load-balancer-controller v2.5.4 Automated Chart Sync! 🤖🤖

  ### Release Notes 📝:

  ## v2.5.4 (requires Kubernetes 1.22+)

## [Documentation](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.5/)

Image: public.ecr.aws/eks/aws-load-balancer-controller:v2.5.4
Thanks to all our contributors! 😊

## Fixes

* Fixed a bug in the eventhandler that was ignoring the update event triggered by `--sync-period` and preventing the auto-reconciliation of the controller. From this version, the controller will reconcile all the resources even if there is no change in manifest, per the default interval of 10hr. For more information, please refer to the [doc](https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/main/docs/deploy/configurations.md#sync-period)

## Changelog since v2.5.3

* doc enhancement for waf addons and reconciliation ([#3281](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/3281), @oliviassss)
* update protobuf to the latest version ([#3274](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/3274), @oliviassss)
* fix the bug that evenhanlder ignores the update per sync-period ([#3280](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/3280), @oliviassss)